### PR TITLE
fix: Update example using typescript-ioc

### DIFF
--- a/di.md
+++ b/di.md
@@ -147,13 +147,13 @@ export class FooService {
 
 ## typescript-ioc
 
-Here is some example code to setup the controller with typescript-ioc.
+Here is some example code to setup the controller with [typescript-ioc](https://github.com/thiagobustamante/typescript-ioc).
 
 `./controllers/fooController.ts`
 
 ```ts
 import { Route } from 'tsoa';
-import { Inject, Provides } from "typescript-ioc";
+import { Inject, Singleton } from "typescript-ioc";
 
 @Route('foo')
 export class FooController {
@@ -164,7 +164,7 @@ export class FooController {
 
 }
 
-@Provides(FooService)
+@Singleton
 export class FooService {
 
 }


### PR DESCRIPTION
[Looks like](https://github.com/thiagobustamante/typescript-ioc#provided-provides-and-provider-interface-removed) `@Provides` was dropped in the new version, so I swapped it for `@Singleton`. Also added a link to the `typescript-ioc` repo.