### PR TITLE
Added @format uuid

### DIFF
--- a/descriptions.md
+++ b/descriptions.md
@@ -100,6 +100,7 @@ That said, duplicating the description all over the code is a lot of effort, let
  * Stringified UUIDv4.
  * See [RFC 4112](https://tools.ietf.org/html/rfc4122)
  * @pattern [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}
+ * @format uuid
  */
 export type UUID = string;
 ```


### PR DESCRIPTION
I added `@format uuid` to the annotation in the UUID type example.
Tsoa knows how to add this to the OpenApi documentation and Swagger-ui then shows an improved example for fields that use it: "3fa85f64-5717-4562-b3fc-2c963f66afa6", instead of "string".

This format field can also be used by some code gen tools, which is how I stumbled on it.

THE IMAGE HAS NOT BEEN UPDATED! THIS WILL MAKE THE SWAGGER-UI SCREENSHOT IN DOCUMENTATION OUT-OF-DATE!
I did not find the source code so could not make a new screenshot.
The only change to the image is that it should now show `string ($uuid)` instead of `string`
BEFORE:
![image](https://user-images.githubusercontent.com/41551215/112727100-15f4f580-8f21-11eb-9ebc-18b61e622b38.png)
AFTER:
![image](https://user-images.githubusercontent.com/41551215/112727111-25743e80-8f21-11eb-808b-ad3b237303ad.png)
