### PR TITLE
Clarify emitDecoratorMetadata requirement in getting-started

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -69,7 +69,7 @@ For a full list of all the possible config, take a look at the [API Reference](h
 While the default ts config will work for this guide, an improved tsconfig.json would look something like this:
 ::: details
 
-```js
+```jsonc
 {
   "compilerOptions": {
     /* Basic Options */
@@ -101,7 +101,7 @@ While the default ts config will work for this guide, an improved tsconfig.json 
 
     /* Experimental Options */
     "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
+    // emitDecoratorMetadata is not needed by tsoa (unless you are using Custom Middlewares)
 
     /* Advanced Options */
     "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
Follows #77 

Fully addresses https://github.com/lukeautry/tsoa/issues/1443

## Why consider this change?
- `emitDecoratorMetadata` has significant consequences for output JS
  - TypeScript-only changes (e.g. changing type signature, `import` vs `import type`, etc) are no longer build-only risks. They can now impact runtime code when you have this setting enabled
- `emitDecoratorMetadata` is particularly troublesome with `isolatedModules`, which is required by projects like esbuild, vite, swc, babel, next.js, and create-react-app
- see [this eslint bug thread](https://github.com/typescript-eslint/typescript-eslint/issues/5468) for an example deep dive into problems
- because of these complexities, any library that uses decorators should ideally clarify if `emitDecoratorMetadata` is required or not