### PR TITLE
docs: update Spectral link

### DIFF
--- a/docs/descriptions.md
+++ b/docs/descriptions.md
@@ -7,7 +7,7 @@ In order stay true to our efforts to avoid code duplication, tsoa uses JSDoc bas
 tsoa does not check if you provide descriptions.
 
 We recommend using a linter
-(we love [Spectral](https://stoplight.io/p/docs/gh/stoplightio/spectral)) to ensure your specifications aren't just correct,
+(we love [Spectral](https://stoplight.io/open-source/spectral)) to ensure your specifications aren't just correct,
 but also contain descriptions and correct [examples](./examples).
 :::
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -11,7 +11,7 @@ Incorrect examples will not break your compilation, because OpenAPI [explicitly 
 You may also just want to demonstrate tsoa's validation :smirk:
 
 We recommend using a linter
-(we love [Spectral](https://stoplight.io/p/docs/gh/stoplightio/spectral)) to ensure your specifications aren't just correct,
+(we love [Spectral](https://stoplight.io/open-source/spectral)) to ensure your specifications aren't just correct,
 but also contain [descriptions](./descriptions) and correct examples.
 :::
 


### PR DESCRIPTION
Updated the Spectral URL in docs/descriptions.md and docs/examples.md to the correct link.