### PR TITLE
docs(generating): fix link to runtime config reference

### DIFF
--- a/docs/generating.md
+++ b/docs/generating.md
@@ -35,7 +35,7 @@ Options:
   --basePath  Base API path                                                                     [string]
 ```
 
-You can find the Reference for the tsoa configuration file [here](https://tsoa-community.github.io/reference/interfaces/_tsoa_runtime.config-1.html)
+You can find the Reference for the tsoa configuration file [here](https://tsoa-community.github.io/reference/interfaces/_tsoa_runtime.Config.html)
 
 For information on the configuration object (tsoa.json), you may also me interested in:
 


### PR DESCRIPTION
Updates the runtime config reference link to the correct URL.