### PR TITLE
docs: correct examples in annotations.md

### DIFF
--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -22,11 +22,11 @@ Examples:
 interface CustomerDto {
     /**
      * @isInt we would kindly ask you to provide a number here
-     * @minimum minimum age is 18
+     * @minimum 18 minimum age is 18
      */
     age: number;
     /**
-     * @minLength 1 at least 1 category is required
+     * @minItems 1 at least 1 category is required
      */
     tags: string[];
     /**


### PR DESCRIPTION

* Use `@minItems` instead of `@minLength` for arrays.
Docs for array: https://json-schema.org/understanding-json-schema/reference/array#length
Docs for string: https://json-schema.org/understanding-json-schema/reference/string#length

* Add the missing argument to `@minimum` 
